### PR TITLE
Add locale support

### DIFF
--- a/lib/alexa_skills_ruby/json_objects/base_request.rb
+++ b/lib/alexa_skills_ruby/json_objects/base_request.rb
@@ -1,7 +1,7 @@
 module AlexaSkillsRuby
   module JsonObjects
     class BaseRequest < JsonObject
-      attributes :type, :request_id, :timestamp
+      attributes :type, :request_id, :timestamp, :locale
 
       def self.new(*args, &block)
         json = args.first

--- a/spec/fixtures/example_launch.json
+++ b/spec/fixtures/example_launch.json
@@ -14,6 +14,7 @@
   "request": {
     "type": "LaunchRequest",
     "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
-    "timestamp": "2015-05-13T12:34:56Z"
+    "timestamp": "2015-05-13T12:34:56Z",
+    "locale": "en-US"
   }
 }

--- a/spec/unit/json_objects/skills_request_spec.rb
+++ b/spec/unit/json_objects/skills_request_spec.rb
@@ -30,6 +30,7 @@ describe AlexaSkillsRuby::JsonObjects::SkillsRequest do
     expect(r.request.type).to eq 'LaunchRequest'
     expect(r.request.request_id).to eq 'amzn1.echo-api.request.0000000-0000-0000-0000-00000000000'
     expect(r.request.timestamp).to eq '2015-05-13T12:34:56Z'
+    expect(r.request.locale).to eq 'en-US'
   end
 
   it 'constructs an intent request' do
@@ -38,6 +39,7 @@ describe AlexaSkillsRuby::JsonObjects::SkillsRequest do
     expect(r.request.type).to eq 'IntentRequest'
     expect(r.request.request_id).to eq 'amzn1.echo-api.request.0000000-0000-0000-0000-00000000000'
     expect(r.request.timestamp).to eq '2015-05-13T12:34:56Z'
+    expect(r.request.locale).to eq 'en-US'
     expect(r.request.intent).to be_a AlexaSkillsRuby::JsonObjects::Intent
     expect(r.request.intent.name).to eq 'GetZodiacHoroscopeIntent'
     expect(r.request.intent.slots).to be_a Hash
@@ -50,6 +52,7 @@ describe AlexaSkillsRuby::JsonObjects::SkillsRequest do
     expect(r.request.type).to eq 'SessionEndedRequest'
     expect(r.request.request_id).to eq 'amzn1.echo-api.request.0000000-0000-0000-0000-00000000000'
     expect(r.request.timestamp).to eq '2015-05-13T12:34:56Z'
+    expect(r.request.locale).to eq 'en-US'
     expect(r.request.reason).to eq 'USER_INITIATED'
   end
 


### PR DESCRIPTION
Alexa is now sending `locale` in the request object.  Details on this can be found in this document: [Developing Skills in Multiple Languages - Instructions](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/developing-skills-in-multiple-languages)

This PR adds support for capturing the `locale` sent in with the request.